### PR TITLE
Add more customization options

### DIFF
--- a/src/main/java/com/vlsolutions/swing/docking/AutoHideButton.java
+++ b/src/main/java/com/vlsolutions/swing/docking/AutoHideButton.java
@@ -19,8 +19,10 @@ You can read the complete license here :
 package com.vlsolutions.swing.docking;
 
 import javax.swing.*;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.Color;
 import java.awt.Insets;
 import java.awt.Dimension;
 import java.beans.*;
@@ -53,6 +55,9 @@ public class AutoHideButton extends JLabel {
 	private Timer notificationTimer; // blinking timer
 	private int blinkCount = 0;
 	private int MAX_BLINKS = UIManager.getInt("DockingDesktop.notificationBlinkCount");
+
+	private Color highlightColor = UIManager.getColor("VLDocking.highlight");
+	private Color bgColor = UIManager.getColor("AutoHideButton.background");
 
 	private PropertyChangeListener keyListener = new PropertyChangeListener() {
 
@@ -107,7 +112,7 @@ public class AutoHideButton extends JLabel {
 			setBackground(UIManager.getColor("DockingDesktop.notificationColor"));
 			setOpaque(true);
 		} else {
-			setOpaque(false);
+		    setHighlighted(false);
 		}
 		repaint();
 	}
@@ -142,7 +147,8 @@ public class AutoHideButton extends JLabel {
 
 		setFocusable(true);
 
-		setOpaque(false);
+		setBackground(bgColor);
+		setOpaque(bgColor != null);
 
 		setIconTextGap(4);
 		setAlignmentY(1);
@@ -191,11 +197,22 @@ public class AutoHideButton extends JLabel {
 	/** Selects or unselects the button */
 	public void setSelected(boolean selected) {
 		this.selected = selected;
-		setOpaque(selected);
-		repaint();
+		setHighlighted(selected);
 		if(selected) {
 			key.setNotification(false); // in case we were in notification mode
 		}
+	}
+	
+	/** Sets the button highlight (on rollover, etc.) */
+	public void setHighlighted(boolean highlighted) {
+	    if (highlighted) {
+    	    setBackground(highlightColor);
+            setOpaque(true);
+	    } else {
+	        setBackground(bgColor);
+	        setOpaque(bgColor != null);
+	    }
+	    repaint();
 	}
 
 	public String getUIClassID() {

--- a/src/main/java/com/vlsolutions/swing/docking/AutoHideButtonPanel.java
+++ b/src/main/java/com/vlsolutions/swing/docking/AutoHideButtonPanel.java
@@ -101,22 +101,17 @@ public class AutoHideButtonPanel extends JPanel {
 
 	private class ButtonHighlighter extends MouseAdapter {
 
-		Color highlight = UIManager.getColor("VLDocking.highlight");
-
 		public void mouseEntered(MouseEvent e) {
 			AutoHideButton btn = (AutoHideButton) e.getSource();
 			if(! btn.isSelected()) { // selected buttons have their own pain style
-				btn.setBackground(highlight);
-				btn.setOpaque(true);
-				btn.repaint();
+			    btn.setHighlighted(true);
 			}
 		}
 
 		public void mouseExited(MouseEvent e) {
 			AutoHideButton btn = (AutoHideButton) e.getSource();
 			if(! btn.isSelected()) { // selected buttons have their own pain style
-				btn.setOpaque(false);
-				btn.repaint();
+			    btn.setHighlighted(false);
 			}
 		}
 	}

--- a/src/main/java/com/vlsolutions/swing/docking/ui/AutoHideButtonPanelUI.java
+++ b/src/main/java/com/vlsolutions/swing/docking/ui/AutoHideButtonPanelUI.java
@@ -21,6 +21,7 @@ package com.vlsolutions.swing.docking.ui;
 import com.vlsolutions.swing.docking.AutoHideButtonPanel;
 import com.vlsolutions.swing.docking.DockingConstants;
 
+import java.awt.Color;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -59,12 +60,14 @@ public class AutoHideButtonPanelUI extends BasicPanelUI implements PropertyChang
 	public void installUI(JComponent comp) {
 		super.installUI(comp);
 		installBorder((AutoHideButtonPanel) comp);
+		installBackground(comp);
 		comp.addPropertyChangeListener(AutoHideButtonPanel.PROPERTY_BORDERZONE, this);
 	}
 
 	public void uninstallUI(JComponent comp) {
 		super.uninstallUI(comp);
 		comp.setBorder(null);
+		comp.setBackground(null);
 		comp.removePropertyChangeListener(this);
 	}
 
@@ -85,6 +88,13 @@ public class AutoHideButtonPanelUI extends BasicPanelUI implements PropertyChang
 		}
 	}
 
+	protected void installBackground(JComponent comp) {
+	    Color color = UIManager.getColor("AutoHideButtonPanel.background");
+        if (color != null) {
+            comp.setBackground(color);
+        }
+	}
+	
 	public void propertyChange(PropertyChangeEvent e) {
 		installBorder((AutoHideButtonPanel) e.getSource());
 	}

--- a/src/main/java/com/vlsolutions/swing/docking/ui/AutoHideButtonUI.java
+++ b/src/main/java/com/vlsolutions/swing/docking/ui/AutoHideButtonUI.java
@@ -118,7 +118,7 @@ public class AutoHideButtonUI extends BasicLabelUI implements PropertyChangeList
 	public void paint(Graphics g, JComponent comp) {
 		AutoHideButton btn = (AutoHideButton) comp;
 		int zone = btn.getZone();
-		if(zone == DockingConstants.INT_HIDE_TOP || zone == DockingConstants.INT_SPLIT_BOTTOM) {
+		if(zone == DockingConstants.INT_HIDE_TOP || zone == DockingConstants.INT_HIDE_BOTTOM) {
 			super.paint(g, comp);
 		} else {
 			// vertical button : we have to rely on a custom paint

--- a/src/main/java/com/vlsolutions/swing/docking/ui/DockViewTitleBarUI.java
+++ b/src/main/java/com/vlsolutions/swing/docking/ui/DockViewTitleBarUI.java
@@ -62,7 +62,7 @@ import javax.swing.plaf.PanelUI;
 public class DockViewTitleBarUI extends PanelUI implements PropertyChangeListener {
 
 	/* hack to use custom painting except on mac os (ugly opacity effects)  */
-	private static boolean useCustomPaint = System.getProperty("os.name").toLowerCase().indexOf("mac os") < 0;
+	private static boolean useCustomPaint = !System.getProperty("os.name").contains("OS X");
 
 	private static Color panelColor = UIManager.getColor("Panel.background");
 	@SuppressWarnings("unused")

--- a/src/main/java/com/vlsolutions/swing/docking/ui/DockViewTitleBarUI.java
+++ b/src/main/java/com/vlsolutions/swing/docking/ui/DockViewTitleBarUI.java
@@ -62,7 +62,8 @@ import javax.swing.plaf.PanelUI;
 public class DockViewTitleBarUI extends PanelUI implements PropertyChangeListener {
 
 	/* hack to use custom painting except on mac os (ugly opacity effects)  */
-	private static boolean useCustomPaint = !System.getProperty("os.name").contains("OS X");
+	private static boolean useCustomPaint = !System.getProperty("os.name").contains("OS X")
+	        && !UIManager.getBoolean("DockViewTitleBar.disableCustomPaint");
 
 	private static Color panelColor = UIManager.getColor("Panel.background");
 	@SuppressWarnings("unused")


### PR DESCRIPTION
The following parts of the VLDocking interface are currently impossible or cumbersome to customize:

- `AutoHideButton` background color: `setOpacity()` is currently used (and from outside the UI class) to change the appearance, which precludes color customization.
- `DockViewTitleBar` gradient: Currently impossible to disable without completely reimplementing the UI class.
- `AutoHideButtonPanel` background color: Only settable by overriding the UI class.

This patch allows the above to be customized via the following `UIManager` keys:

- `AutoHideButton.background` (`Color`)
- `DockViewTitleBar.disableCustomPaint` (`Boolean`)
- `AutoHideButtonPanel.background` (`Color`)

When these are not specified (`null`) the behavior is identical to before.

I'm not sure where the new keys should be documented. Please let me know.