### PR TITLE
Fix for when awt.font.desktophints is null (can be on Linux, apparently)

### DIFF
--- a/src/main/java/com/vlsolutions/swing/tabbedpane/JTabbedPaneSmartIcon.java
+++ b/src/main/java/com/vlsolutions/swing/tabbedpane/JTabbedPaneSmartIcon.java
@@ -117,7 +117,10 @@ public class JTabbedPaneSmartIcon implements Icon, Cloneable {
 		try {
 		    defaultHints = (Map) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
 		} catch(AWTError ignore) {
-		    defaultHints = new RenderingHints(null);
+		} finally {
+		    if (defaultHints == null) {
+		        defaultHints = new RenderingHints(null);
+		    }
 		}
 
 	}


### PR DESCRIPTION
This fixes a bug in my rendering hints patch (sorry).

I thought the hints map was guaranteed to be non-null, but I was wrong—on Linux it can be.